### PR TITLE
Changes on the job handling

### DIFF
--- a/openshift/cronjob.yaml
+++ b/openshift/cronjob.yaml
@@ -12,10 +12,11 @@ objects:
       name: quay-mysql-diag
   spec:
     schedule: ${SCHEDULE}
+    concurrencyPolicy: Forbid
     jobTemplate:
       spec:
-        backoffLimit: 3
-        activeDeadlineSeconds: 50
+        backoffLimit: ${{BACKOFF_LIMIT}}
+        activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
         template:
           spec:
             restartPolicy: OnFailure
@@ -90,3 +91,7 @@ parameters:
   value: "quay-mysql-diag-s3"
 - name: QUAY_CONFIG_SECRET
   value: "quay-config-secret"
+- name: BACKOFF_LIMIT
+  value: "5"
+- name: ACTIVE_DEADLINE_SECONDS
+  value: "1200"


### PR DESCRIPTION
* Do not allow for concurrent jobs. If the previous one hasn't ended
  when the new one needs to be triggered, it will be skipped
* Let things run for more time to always try to get data

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>